### PR TITLE
Add document detailing narrative parser tokens.

### DIFF
--- a/docs/advanced/narrative_parser_tokens.md
+++ b/docs/advanced/narrative_parser_tokens.md
@@ -1,0 +1,41 @@
+# Fungus Advanced - Narrative Parser Tokens Reference
+
+The following tokens can be used within Story Text to do things such as change the styling of text or clear the contents of a dialog area on input and much more.
+
+* {b} - Bold start
+* {/b} - Bold end
+* {i} - Italic start
+* {/i} - Italic end
+* {color=red} - Color start
+* {/color} - Color end
+* {w} - Wait
+* {w=0.5} - Wait for a certain amount of time
+* {wi} - Wait for input, but do not clear the dialog area
+* {wc} - Wait for input, clear the dialog area after input
+* {wp} - Wait on punctutation start
+* {wp=0.5} - Wait on punctutation (after a certain amount of time) start
+* {/wp} - Wait on punctuation end
+* {c} - Clear the dialog area
+* {s} - Speed start
+* {s=60} - Speed (with speed setting) start
+* {/s} - Speed end
+* {x} - Exit
+* {m=MessageName} - Send a message with `MessageName`
+* {vpunch=0.5} - Vertical punch
+* {hpunch=0.5} - Horizontal punch
+* {shake=0.5} - Shake
+* {shiver=0.5} - Shiver
+* {flash=0.5} - Flash
+* {audio=Sound} - Audio start for `Sound`
+* {audioloop=Sound} - Audio loop for `Sound`
+* {audiopause=Sound} - Audio pause for `Sound`
+* {audiostop=Sound} - Audio stop for `Sound`
+
+Examples:
+
+```
+This is a line of dialog.
+{wc}
+This is another line of dialog with some {b}bold{/b} styling.
+This is another line of dialog with some {color=blue}blue{/b} text.
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: Documentation and user guide for Fungus Unity dialog system
 site_favicon: images/favicon.ico
 pages:
 - Home: index.md
-- Recipes: 
+- Recipes:
     - Quickstart: recipes/index.md
     - Next steps: recipes2/index.md
     - Audio: audio/index.md
@@ -27,6 +27,8 @@ pages:
     - Events (Core) Commands: commands/event_handlers/core_events.md
     - Events (Input) Commands: commands/event_handlers/input_events.md
     - Events (Sprite) Commands: commands/event_handlers/sprite_events.md
+- Advanced Reference:
+    - Narrative Parser Tokens: advanced/narrative_parser_tokens.md
 
 theme: readthedocs
 


### PR DESCRIPTION
I'm not sure where you'd like this referenced, but I thought it'd be useful to have a reference of the narrative parser tokens so that anyone can more easily discover what's possible with Story Text. Let me know if there are any changes you'd like to see made. 